### PR TITLE
fix(program): reorder signers for correct fee payer

### DIFF
--- a/programs/solstreams/src/lib.rs
+++ b/programs/solstreams/src/lib.rs
@@ -121,14 +121,14 @@ pub struct CreateEventStream<'info> {
 )]
 /// CreateEvent is used to create an event on a stream
 pub struct CreateEvent<'info> {
-    /// owner is the owner of the stream
-    #[account(mut)]
-    pub owner: Signer<'info>,
-
     /// user is the final payer of the
     /// event creation
     #[account(mut)]
     pub user: Signer<'info>,
+
+    /// owner is the owner of the stream
+    #[account(mut)]
+    pub owner: Signer<'info>,
 
     #[account(mut,
         // check that the owner field of Stream matches the 


### PR DESCRIPTION
It seems as if the first signer is responsible for the fee payment of the tx
https://solscan.io/tx/2JjL8nAMZMdSLCrMfQJGPw7v92yVGsoBxCD5BtyjUe75uAPs1cfZ7gNDRMFDP6kFVG1usNLmnDoWSaP13ZGEBW1r?cluster=testnet

Fix: let the user pay the fee and account rent 